### PR TITLE
EventListener Removal on Close

### DIFF
--- a/src/com/reyco1/multiuser/MultiUserSession.as
+++ b/src/com/reyco1/multiuser/MultiUserSession.as
@@ -146,11 +146,20 @@ package com.reyco1.multiuser
 		}
 		
 		/**
-		 * Closes the connection 
+		 * Closes the connection and removes all associated Event Listeners.
 		 * 
 		 */		
 		public function close():void
 		{
+			P2PDispatcher.removeEventListener(ChatMessageEvent.RECIEVE		, handleChatMessage);
+			P2PDispatcher.removeEventListener(UserStatusEvent.CONNECTED		, handleConnect);
+			P2PDispatcher.removeEventListener(UserStatusEvent.DISCONNECTED	, handleClose);
+			P2PDispatcher.removeEventListener(UserStatusEvent.USER_ADDED	, handleUserAdded);
+			P2PDispatcher.removeEventListener(UserStatusEvent.USER_REMOVED	, handleUserRemoved);
+			P2PDispatcher.removeEventListener(UserStatusEvent.USER_EXPIRED	, handleUserExpired);
+			P2PDispatcher.removeEventListener(UserStatusEvent.USER_IDLE		, handleUserIdle);
+			Logger.log("global listeners removed", this);
+			
 			session.close();
 		}
 		

--- a/src/com/reyco1/multiuser/core/Session.as
+++ b/src/com/reyco1/multiuser/core/Session.as
@@ -122,7 +122,7 @@ package com.reyco1.multiuser.core
 		}
 		
 		/**
-		 *Closes the connectionand sets the NetConnection instance to null 
+		 * Closes the connection, sets the NetConnection instance to null, removes related EventListeners, and closes the associated UserGroup 
 		 * 
 		 */		
 		public function close():void
@@ -131,6 +131,12 @@ package com.reyco1.multiuser.core
 			
 			connection.close();
 			connection = null;
+			
+			if (group)
+			{
+				group.removeEventListener(NetStatusEvent.NET_STATUS, handleNetStatusEvent);
+				group.close();
+			}
 		}
 	}
 }

--- a/src/com/reyco1/multiuser/group/UserGroup.as
+++ b/src/com/reyco1/multiuser/group/UserGroup.as
@@ -49,6 +49,11 @@ package com.reyco1.multiuser.group
 		 */		
 		public var userList:Object;
 		
+		/**
+		 * The connection the UserGroup was created with
+		 */
+		private var connection:NetConnection;
+		
 		protected var userName:String;
 		protected var userDetails:Object;		
 		protected var nearID:String;
@@ -79,6 +84,35 @@ package com.reyco1.multiuser.group
 			
 			connection.addEventListener(NetStatusEvent.NET_STATUS, createOwnUser);
 			addEventListener(NetStatusEvent.NET_STATUS, netStatusHandler);
+			
+			//Store connection for EventListener removal.
+			this.connection = connection;
+		}
+		
+		/**
+		 * Remove all EventListeners and stop timers.
+		 * 
+		 */		
+		override public function close():void
+		{
+			connection.removeEventListener(NetStatusEvent.NET_STATUS, createOwnUser);
+			removeEventListener(NetStatusEvent.NET_STATUS, netStatusHandler);
+			
+			if (keepAliveTimer)
+			{
+				keepAliveTimer.stop();
+				keepAliveTimer.removeEventListener(TimerEvent.TIMER, announceSelf);
+			}
+			
+			if (expiredTimer)
+			{
+				expiredTimer.stop();
+				expiredTimer.removeEventListener(TimerEvent.TIMER, invalidateUserList);
+			}
+			
+			connection = null;
+			
+			super.close();
 		}
 		
 		protected function netStatusHandler(event:NetStatusEvent):void


### PR DESCRIPTION
Stops crashes that resulted from reconnecting or creating a new
MultiUserSession with a different GroupName.
